### PR TITLE
Fix floating IP on bastion host.

### DIFF
--- a/20_res_bastion.tf
+++ b/20_res_bastion.tf
@@ -23,7 +23,7 @@ resource "openstack_compute_instance_v2" "bastion" {
 }
 
 resource "openstack_networking_floatingip_v2" "bastion_float" {
-  pool = "public"
+  pool = var.external_network-name
 }
 
 resource "openstack_compute_floatingip_associate_v2" "bastion_float" {


### PR DESCRIPTION
Deployment fails unless your external network is actually named `public`. This commit makes use of the variable `external_network-name` as mentioned in the README.